### PR TITLE
change parser from "postcss" to "css"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
             prettierOptions.tabWidth = indentation;
         }
     }
-    prettierOptions.parser = 'postcss';
+    prettierOptions.parser = 'css';
     debug('prettier %O', prettierOptions);
     debug('linter %O', stylelintConfig);
 


### PR DESCRIPTION
switching to css parser to get remove the deprecation message
```
{ "parser": "postcss" }` is deprecated. Prettier now treats it as `{ "parser": "css" }
```