### PR TITLE
Handle error when prettierOptions is passed as null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,10 @@ function resolveConfig({
 resolveConfig.resolve = (stylelintConfig, prettierOptions = {}) => {
     const { rules } = stylelintConfig;
 
+    if (prettierOptions === null) {
+        prettierOptions = {};
+    }
+
     if (rules['max-line-length']) {
         const printWidth = rules['max-line-length'][0];
 


### PR DESCRIPTION
In some instances, `prettierOptions` can be passed as null, instead of being left undefined. This will cause an error as detailed in #9.

This PR adds a check to on the parameter to see if it is null and sets it to an empty object if so. This closes #9.

Further testing may be required.